### PR TITLE
chore: 🔧 update Go version in documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ Thanks for your interest in contributing! This monorepo hosts the Nomos CLI and 
 > Standards first: This project follows the Development Standards Constitution from the general-standards space (quality gates, code review, testing). Conventional Commits with gitmoji are required.
 
 ## Prerequisites
-- Go 1.22+
+- Go 1.25+
 - Git
 - macOS, Linux, or Windows
 - Optional: golangci-lint (for `make lint`)

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Nomos libraries are published as independent Go modules and can be imported into
 // In your project's go.mod
 module github.com/example/my-project
 
-go 1.22
+go 1.25
 
 require (
     github.com/autonomous-bits/nomos/libs/compiler v0.1.0


### PR DESCRIPTION
- Changed Go version requirement from 1.22 to 1.25 in CONTRIBUTING.md and README.md
- Ensures compatibility with the latest features and improvements in Go