### PR TITLE
chore(docs): 🔧 update CI helper script path in README and remove old …

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ make test
 ```
 
 - Module docs and architecture guidance: see [docs/architecture/go-monorepo-structure.md](docs/architecture/go-monorepo-structure.md)
-- CI helper: `./scripts/verify-ci-modules.sh` validates workspace and runs tests
+- CI helper: `./tools/scripts/verify-ci-modules.sh` validates workspace and runs tests
   
 Each module maintains its own `go.mod`, `README.md`, and `CHANGELOG.md`.
 

--- a/tools/scripts/verify-ci-modules.sh
+++ b/tools/scripts/verify-ci-modules.sh
@@ -3,7 +3,7 @@
 # verify-ci-modules.sh
 # Fast CI smoke test that validates workspace integrity and runs tests across all modules.
 #
-# Usage: ./scripts/verify-ci-modules.sh
+# Usage: ./tools/scripts/verify-ci-modules.sh
 
 set -euo pipefail
 


### PR DESCRIPTION
This pull request updates the location of the CI helper script and its references to improve consistency in the repository structure. The main change is moving the `verify-ci-modules.sh` script from the `scripts` directory to `tools/scripts`, and updating documentation and script usage accordingly.

Repository structure and documentation updates:

* Renamed `scripts/verify-ci-modules.sh` to `tools/scripts/verify-ci-modules.sh` and updated the usage instructions within the script to reflect the new path.
* Updated the reference to the CI helper script in the `README.md` to point to `./tools/scripts/verify-ci-modules.sh` instead of the old location.