### PR TITLE
docs(changelog): 📝 prepare CLI v1.1.0 release

### DIFF
--- a/apps/command-line/CHANGELOG.md
+++ b/apps/command-line/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0] - 2025-12-28
+
 ### Removed
 - [CLI] YAML and HCL serialization stubs removed (#phase6)
   - `ToYAML()` and `ToHCL()` functions removed from `internal/serialize`


### PR DESCRIPTION
Prepare CHANGELOG for CLI v1.1.0 release with YAML/HCL serialization removal moved from Unreleased to v1.1.0 section.