### PR TITLE
chore: 🔧 remove specs folder from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,4 @@ site/
 .github/agents/
 .github/prompts/
 .specify/
+specs/


### PR DESCRIPTION
- Eliminated the `specs/` directory from being ignored.
- This change allows tracking of specification files in the repository.