### PR TITLE
docs: 📝 update Go version references to 1.25.6 across documentation and examples

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ Thanks for your interest in contributing! This monorepo hosts the Nomos CLI and 
 > Standards first: This project follows the Development Standards Constitution from the general-standards space (quality gates, code review, testing). Conventional Commits with gitmoji are required.
 
 ## Prerequisites
-- Go 1.25+
+- Go 1.25.6+
 - Git
 - macOS, Linux, or Windows
 - Optional: golangci-lint (for `make lint`)
@@ -145,7 +145,7 @@ go work sync
 ```
 
 **Problem:** Module requires newer Go version  
-**Solution:** Update Go installation to 1.25+ or check `go.mod` for required version.
+**Solution:** Update Go installation to 1.25.6+ or check `go.mod` for required version.
 
 ### Still Having Issues?
 

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ Nomos libraries are published as independent Go modules and can be imported into
 // In your project's go.mod
 module github.com/example/my-project
 
-go 1.25
+go 1.25.6
 
 require (
     github.com/autonomous-bits/nomos/libs/compiler v0.1.0

--- a/apps/command-line/README.md
+++ b/apps/command-line/README.md
@@ -21,7 +21,7 @@ The CLI is a thin wrapper around the compiler library (`libs/compiler`) and is r
 
 ### Prerequisites
 
-- Go 1.25 or later
+- Go 1.25.6 or later
 - macOS, Linux, or Windows (tested primarily on macOS)
 
 ### Build from Source
@@ -976,7 +976,7 @@ tags = []              # empty list
 
 ### Prerequisites
 
-- Go 1.25 or later
+- Go 1.25.6 or later
 - Access to `libs/compiler` and `libs/parser` via workspace
 
 ### Building

--- a/docs/architecture/go-monorepo-structure.md
+++ b/docs/architecture/go-monorepo-structure.md
@@ -168,7 +168,7 @@ Go 1.18+ introduced workspaces, which are essential for monorepo management.
 Create a `go.work` file at the repository root:
 
 ```go
-go 1.25
+go 1.25.6
 
 use (
     ./apps/command-line
@@ -360,7 +360,7 @@ Use workspace features for local development:
 // apps/command-line/go.mod
 module github.com/autonomous-bits/nomos/apps/command-line
 
-go 1.25
+go 1.25.6
 
 require (
     github.com/autonomous-bits/nomos/libs/compiler v0.1.0
@@ -553,7 +553,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.25'
+          go-version: '1.25.6'
           
       - name: Test
         run: go test -v -race -coverprofile=coverage.txt ./...
@@ -571,7 +571,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.25'
+          go-version: '1.25.6'
           
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v4
@@ -589,7 +589,7 @@ Create contributing guidelines:
 
 ## Development Setup
 
-1. Install Go 1.25 or later
+1. Install Go 1.25.6 or later
 2. Clone the repository
 3. Run `go work sync`
 

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -28,7 +28,7 @@ Each example directory contains:
 ## Prerequisites
 
 - Nomos CLI installed (`nomos` command available)
-- Go 1.25+ (for building example providers)
+- Go 1.25.6+ (for building example providers)
 - Basic understanding of Nomos configuration syntax
 
 ## Running the Examples

--- a/docs/guides/external-providers-migration.md
+++ b/docs/guides/external-providers-migration.md
@@ -168,7 +168,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.25'
+          go-version: '1.25.6'
       
       - name: Install Nomos CLI
         run: |
@@ -195,7 +195,7 @@ jobs:
 ### Docker Example
 
 ```dockerfile
-FROM golang:1.25-alpine AS builder
+FROM golang:1.25.6-alpine AS builder
 
 # Install Nomos CLI
 RUN go install github.com/autonomous-bits/nomos/apps/command-line/cmd/nomos@latest

--- a/docs/guides/removing-replace-directives.md
+++ b/docs/guides/removing-replace-directives.md
@@ -48,7 +48,7 @@ Edit your `go.mod` file to use versioned `require` directives:
 ```go
 module github.com/example/my-project
 
-go 1.25
+go 1.25.6
 
 require (
     github.com/autonomous-bits/nomos/libs/compiler v0.0.0-00010101000000-000000000000
@@ -63,7 +63,7 @@ replace github.com/autonomous-bits/nomos/libs/parser => ../nomos/libs/parser
 ```go
 module github.com/example/my-project
 
-go 1.25
+go 1.25.6
 
 require (
     github.com/autonomous-bits/nomos/libs/compiler v0.1.0
@@ -155,7 +155,7 @@ If you're working within the Nomos monorepo itself, **do not use `replace` direc
 The repository root has a `go.work` file that configures all modules:
 
 ```go
-go 1.25+
+go 1.25.6+
 
 use (
     ./apps/command-line

--- a/examples/consumer/README.md
+++ b/examples/consumer/README.md
@@ -32,7 +32,7 @@ Once Nomos libraries are published with version tags, external consumers can add
 ```go
 module github.com/example/my-project
 
-go 1.25
+go 1.25.6
 
 require (
     github.com/autonomous-bits/nomos/libs/compiler v0.1.0

--- a/libs/compiler/test/providerproc_manager_test.go
+++ b/libs/compiler/test/providerproc_manager_test.go
@@ -206,7 +206,7 @@ func createFakeProviderBinary(t *testing.T) string {
 	// Create a go.mod for the fake provider
 	goMod := fmt.Sprintf(`module fake-provider
 
-go 1.25
+go 1.25.6
 
 require (
 	github.com/autonomous-bits/nomos/libs/provider-proto v0.0.0

--- a/tools/scripts/test-consumer.sh
+++ b/tools/scripts/test-consumer.sh
@@ -67,7 +67,7 @@ cd "$TEMP_DIR"
 cat > go.mod << 'EOF'
 module example.com/test-consumer
 
-go 1.25
+go 1.25.6
 
 require (
     github.com/autonomous-bits/nomos/libs/compiler v0.1.0


### PR DESCRIPTION
- Updated prerequisites in multiple README files and guides.
- Ensured consistency in Go version across all relevant documentation.