### PR TITLE
chore: prepare release for parser v0.9.0 and provider-proto v0.2.1

### DIFF
--- a/libs/parser/CHANGELOG.md
+++ b/libs/parser/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-02-16
+
 ### Changed
 - **BREAKING CHANGE: Root references now use `*`**
   - Root references use `@alias:*` instead of `@alias:.`

--- a/libs/provider-proto/CHANGELOG.md
+++ b/libs/provider-proto/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1] - 2026-02-16
+
+### Changed
+- upgraded Go version to 1.26.0 to fix TLS vulnerabilities
+- Docs: update AGENTS.md with new agent roles
+
 ## [0.2.0] - 2025-12-26
 
 ### Added


### PR DESCRIPTION
This pull request updates the changelogs for both the `parser` and `provider-proto` libraries, documenting recent and upcoming changes. The most important updates include a breaking change to root references in the parser and a Go version upgrade in provider-proto for security reasons.

Changelog updates:

**parser library:**
* Added a new `0.9.0` release entry documenting a breaking change—root references now use `@alias:*` instead of `@alias:.`.

**provider-proto library:**
* Added a new `0.2.1` release entry noting the upgrade to Go 1.26.0 to address TLS vulnerabilities and updated documentation in `AGENTS.md` regarding new agent roles.